### PR TITLE
Prevent null content

### DIFF
--- a/BroPilot/ViewModels/ChatWindowViewModel.cs
+++ b/BroPilot/ViewModels/ChatWindowViewModel.cs
@@ -328,6 +328,11 @@ namespace BroPilot.ViewModels
 
             foreach (var message in messages)
             {
+                if (message.Content == null)
+                {
+                    continue; // OpenAI over Open WebUI, fails on null with: data: {"error": {"detail": "argument of type 'NoneType' is not iterable"}}
+                }
+
                 result.Add(new Message
                 {
                     role = message.Role,


### PR DESCRIPTION
After request fail, a assistent message with content `null` is generated. This lead to error `data: {"error": {"detail": "argument of type 'NoneType' is not iterable"}}` on OpenAI (at least over Open WebUI).

This fixes only the failure, but does only receive the start think part, not the final answer.